### PR TITLE
Getting rid of annoying warnings when compiling under more strict flags

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
           cmake -S . -B build \
             -DCMAKE_CXX_STANDARD=23 \
             -DCMAKE_CXX_STANDARD_REQUIRED=ON \
-            -DBUILD_EXAMPLES=ON
+            -DEMBEDYAML_BUILD_EXAMPLES=ON
 
       - name: Build
         run: cmake --build build --parallel

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/libyaml"]
 	path = external/libyaml
-	url = https://github.com/yaml/libyaml
+	url = https://github.com/joeinman/libyaml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries(EmbedYAML PUBLIC
     yaml
 )
 
-option(BUILD_EXAMPLES "Build examples" OFF)
-if (BUILD_EXAMPLES)
+option(EMBEDYAML_BUILD_EXAMPLES "Build examples" OFF)
+if (EMBEDYAML_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ target_sources(EmbedYAML PRIVATE
 target_include_directories(EmbedYAML PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
+target_include_directories(EmbedYAML SYSTEM INTERFACE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
+
 target_link_libraries(EmbedYAML PUBLIC
     yaml
 )


### PR DESCRIPTION
It just exports the library as a system-wise library so the warnings are not propagated into it.